### PR TITLE
Update CoreCommands.cs

### DIFF
--- a/Apps/CoreCommands.cs
+++ b/Apps/CoreCommands.cs
@@ -13,7 +13,7 @@ namespace com.clusterrr.hakchi_gui
             { "fbalpha2012_cps2", "cps2" },
             { "fbalpha2012_cps3", "cps3" },
             { "fbalpha2012_neogeo", "neo" },
-            { "fb_alpha", "fba2016" },
+            { "fbalpha", "fba2016" },
             { "vba_next", "vba-next" },
             { "mednafen_ngp", "ngp" },
             { "mednafen_supergrafx", "sgfx" },


### PR DESCRIPTION
Update translationTable to point to fbalpha instead of fb_alpha.  Users may have to delete cores.json, cores_ext.json, and cores_systems.json if the cores list is still showing the binary as /bin/fbalpha instead of /bin/fba2016 so that the files are regenerated on next launch.