### PR TITLE
Copyleft update for translation mods

### DIFF
--- a/mods/hmods/copyleft.hmod/etc/preinit.d/p8026_copyleft
+++ b/mods/hmods/copyleft.hmod/etc/preinit.d/p8026_copyleft
@@ -2,12 +2,12 @@ copyleft_mod(){
   local copyleft_text='THIS MODDED SYSTEM IS NOT FOR RESALE!\\n\\nThis console was modded using the free hakchi2 ce software. If you bought an already modded system, you were scammed.\\n'
   local copyleft_cache="$mountpoint/var/copyleft"
   
-  find "$squashfs/usr/share/" -name "strings.*" -print | while read l ; do
-    local modified_string_filename="$copyleft_cache/${l#$squashfs/usr/share/}"
+  find "$mountpoint/usr/share/" -name "strings.*" -print | while read l ; do
+    local modified_string_filename="$copyleft_cache/${l#$mountpoint/usr/share/}"
     
     mkdir -p "$(dirname "$modified_string_filename")"
     [ -f "$modified_string_filename" ] || sed -e "s/\"sys_copyright_games_HeadText\": \"\",/\"sys_copyright_games_HeadText\": \"$copyleft_text\",/g" "$l" > "$modified_string_filename"
-    mount_bind "$modified_string_filename" "$mountpoint/${l#$squashfs/}"
+    mount_bind "$modified_string_filename" "$l"
   done
 }
 copyleft_mod


### PR DESCRIPTION
Right now there's a problem with translation mods and copyleft mod:
- copyleft modifies squashfs strings.lng files
- current translation mods are "old" and use overmount function without the -f option that MM added when he made the overlayfs changes, so the overmount doesnt work
- so, since copyleft is using the squashfs strings.lng and no overmount is actually been made after, the translations are simply not working

With these little changes:
- copyleft happens a bit later so its fully compatible with external UI for example
- it modifies mountpoint strings.lng instead of squashfs ones

So:
- translation mods dont need to overmount anything at all, overlayfs is taking care of that
- backward compatible, because even if the overmount preinit is useless without -f, overlayfs will do his job
- future translation mods will just need to transfer strings.lng, no preinit file required

I hope I didnt overlook anything, I tested it and it works fine for me!