### PR TITLE
Changes to custom backgrounds hmod.

### DIFF
--- a/user_mods/custom_backgrounds.hmod/etc/preinit.d/p8025_backgrounds
+++ b/user_mods/custom_backgrounds.hmod/etc/preinit.d/p8025_backgrounds
@@ -1,1 +1,1 @@
-mount -t overlayfs -o lowerdir="$squashfs/usr/share/backgrounds",upperdir="$mountpoint/var/lib/clover/backgrounds" overlayfs "$mountpoint/var/lib/clover/backgrounds"
+[ -d "$mountpoint/media/$modname/backgrounds" ] && mount -t overlayfs -o lowerdir="$squashfs/usr/share/backgrounds",upperdir="$mountpoint/media/$modname/backgrounds" overlayfs "$mountpoint/usr/share/backgrounds"

--- a/user_mods/custom_backgrounds.hmod/install
+++ b/user_mods/custom_backgrounds.hmod/install
@@ -1,4 +1,2 @@
-local ext_path=$mountpoint/var/lib/clover/backgrounds
-mkdir -p $ext_path
-
+rm -f "$transferpath/usr/share/backgrounds/put_backgrounds_folders_here"
 return 0

--- a/user_mods/custom_backgrounds.hmod/readme.md
+++ b/user_mods/custom_backgrounds.hmod/readme.md
@@ -3,10 +3,10 @@ Name: Custom Backgrounds
 Creator: DanTheMan827
 Category: UI
 ---
-This mod will simply merge the main backgrounds folder with `/var/lib/clover/backgrounds` folder and you can use it to add custom borders without any additional modding.
+This mod will simply transfer your custom borders in `/var/lib/hakchi/rootfs/usr/share/backgrounds` so it can be merged with the main backgrounds folder.
 
-## Notes and Known Issues
+If you're using USB-HOST, you can add your custom borders in `USB:\hakchi\backgrounds`.
 
-> When you uninstall this mod, it will remove all custom borders you've transferred to `/var/lib/clover/backgrounds`
+## Note
 
-> When you uninstall hakchi, it is possible that the custom borders stick. You can use the built-in `restore to factory settings` in your NES/SNES Mini to reset those as well!
+> When you uninstall this mod, it will remove all custom borders you've transferred to `/var/lib/hakchi/rootfs/usr/share/backgrounds`

--- a/user_mods/custom_backgrounds.hmod/uninstall
+++ b/user_mods/custom_backgrounds.hmod/uninstall
@@ -1,2 +1,2 @@
-local ext_path=$mountpoint/var/lib/clover/backgrounds
-rm -rf $ext_path
+local ext_path="$rootfs/usr/share/backgrounds"
+rm -rf "$ext_path"


### PR DESCRIPTION
* Changed path from `/var/lib/clover/backgrounds` to `$rootfs/usr/share/backgrounds`, so its automatically "overlayed" by hakchi on boot.
* Added USB support: if `/media/hakchi/backgrounds` is detected it will be "overlayed" with `$squashfs/usr/share/backgrounds`.