### PR TITLE
More Canoe filters command lines.

### DIFF
--- a/user_mods/snes_custom_filters.hmod/usr/bin/canoe-custom-filters
+++ b/user_mods/snes_custom_filters.hmod/usr/bin/canoe-custom-filters
@@ -41,11 +41,20 @@ while [ $# -gt 0 ] ; do
   --no-scanlines)
     mode1="-filter 1 -magfilter 1"
     ;;
+  --enable-scanlines)
+    mode2="-filter 2 -magfilter 3"
+    mode3="-filter 2 -magfilter 3 --pixel-perfect"
+    ;;
   --no-smooth)
     mode1="-filter 2 -magfilter 3"
     ;;
-  --smooth43)
+  --enable-smooth)
     mode2="-filter 1 -magfilter 1"
+    mode3="-filter 1 -magfilter 1 --pixel-perfect"
+    ;;
+  --crt-mode)
+    mode2="-filter 2 -magfilter 1"
+    mode3="-filter 2 -magfilter 1 --pixel-perfect"
     ;;
   --rollback-mode)
     case "$2" in


### PR DESCRIPTION
* Added `--enable-scanlines` to enable scanlines in 4:3 and Pixel Perfect modes.
* Added `--enable-smooth` to enable bilinear filtering in 4:3 and PP modes.
* Because bilinear is now compatible with PP mode I changed `--smooth43` to `--enable-smooth`.
* Added a `--crt-mode` to enable scanlines + bilinear in 4:3 and PP modes.