### PR TITLE
Added install file to remove "p7071_copyleft" from previous install

### DIFF
--- a/mods/hmods/copyleft.hmod/install
+++ b/mods/hmods/copyleft.hmod/install
@@ -1,0 +1,2 @@
+rm -f "$preinitpath/p7071_copyleft"
+return 0


### PR DESCRIPTION
After updating, the file "p7071_copyleft" from previous version is still there, preventing "p8026_copyleft" to work properly.