### PR TITLE
Canoe filters changes, keeping `--smooth43` for backward compatibilit…

### DIFF
--- a/user_mods/snes_custom_filters.hmod/readme.md
+++ b/user_mods/snes_custom_filters.hmod/readme.md
@@ -7,8 +7,14 @@ This module allows to tweak video filters on SNES Mini or Super Famicom Mini (ye
 
 You need to add special command line arguments to make it work. Just add those arguments to game's command line or to global command line arguments.
 
-Argument to enable bilinear filter in 4:3 mode:  
-  `--smooth43`
+Argument to enable bilinear filter in 4:3 or Pixel Perfect modes:  
+  `--smooth43` or `--enable-smooth`
+
+Argument to enable scanlines in 4:3 or Pixel Perfect modes:  
+  `--enable-scanlines`
+
+Argument to enable both bilinear filter and scanlines in 4:3 or Pixel Perfect modes:  
+  `--crt-mode`
 
 Argument to disable scanlines in CRT mode (bilinear filter only):  
   `--no-scanlines`

--- a/user_mods/snes_custom_filters.hmod/usr/bin/canoe-custom-filters
+++ b/user_mods/snes_custom_filters.hmod/usr/bin/canoe-custom-filters
@@ -41,11 +41,20 @@ while [ $# -gt 0 ] ; do
   --no-scanlines)
     mode1="-filter 1 -magfilter 1"
     ;;
+  --enable-scanlines)
+    mode2="-filter 2 -magfilter 3"
+    mode3="-filter 2 -magfilter 3 --pixel-perfect"
+    ;;
   --no-smooth)
     mode1="-filter 2 -magfilter 3"
     ;;
-  --smooth43)
+  --smooth43|--enable-smooth)
     mode2="-filter 1 -magfilter 1"
+    mode3="-filter 1 -magfilter 1 --pixel-perfect"
+    ;;
+  --crt-mode)
+    mode2="-filter 2 -magfilter 1"
+    mode3="-filter 2 -magfilter 1 --pixel-perfect"
     ;;
   --rollback-mode)
     case "$2" in


### PR DESCRIPTION
…y this time.

* Added `--enable-scanlines` to enable scanlines in 4:3 and Pixel Perfect modes.
* `--smooth43` now enables bilinear filtering in 4:3 and PP modes, not just 4:3.
* Added `--enable-smooth` command, which acts exactly the same as `--smooth43`, but the name makes more sense considering it's now compatible with PP mode.
* Added a `--crt-mode` to enable scanlines + bilinear in 4:3 and PP modes.
* Adjusted readme.