### PR TITLE
header removal

### DIFF
--- a/hakchi_gui/Apps/SnesGame.cs
+++ b/hakchi_gui/Apps/SnesGame.cs
@@ -163,9 +163,9 @@ namespace com.clusterrr.hakchi_gui
             }
 
             // header removal
-            if ((ext.ToLower() == ".smc") && ((rawRomData.Length % 1024) != 0))
+            if ((rawRomData.Length % 1024) != 0)
             {
-                Trace.WriteLine("Removing SMC header");
+                Trace.WriteLine("Removing header");
                 var stripped = new byte[rawRomData.Length - 512];
                 Array.Copy(rawRomData, 512, stripped, 0, stripped.Length);
                 rawRomData = stripped;


### PR DESCRIPTION
Currently Hakchi2 CE will only remove the headers of .smc files, but there are cases when ,fig or .sfc files can also contain a header. For example, a user may manually add a header to a rom in order to apply a patch that requires a headered rom. The result could be a headered .sfc, and Hakchi2 CE would not remove its header.