### PR TITLE
Fix add games task crashing bug

### DIFF
--- a/Tasks/AddGamesTask.cs
+++ b/Tasks/AddGamesTask.cs
@@ -207,7 +207,7 @@ namespace com.clusterrr.hakchi_gui.Tasks
                     }
                     else
                     {
-                        if (app.CoverArtMatches != null && app.CoverArtMatches.Count() > 1)
+                        if (app != null && app.CoverArtMatches != null && app.CoverArtMatches.Count() > 1)
                         {
                             gamesWithMultipleArt.Add(app);
                         }


### PR DESCRIPTION
Fix add games task crashing bug when some of ROM's mapper is not supported by the emulator and you click "No" button on the question if you should add ROM despite the error or not.

How to reproduce the bug:

Try to add a bunch of ROMs and include one with an unsupported mapper, answer no, experience exception and check that only a part of the selected ROMs is added to the list.

![Screenshot_1](https://user-images.githubusercontent.com/22933197/132978294-a870c2aa-a96e-4d9b-a607-27bb5f4e53b4.png)
