### PR TITLE
Fix FR export dialog

### DIFF
--- a/ExportGamesDialog.fr-FR.resx
+++ b/ExportGamesDialog.fr-FR.resx
@@ -117,10 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblSelectDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 13</value>
-  </data>
   <data name="lblSelectDrive.Text" xml:space="preserve">
     <value>Sélectionner le lecteur pour exporter:</value>
   </data>
@@ -129,27 +125,6 @@
   </data>
   <data name="btnCancel.Text" xml:space="preserve">
     <value>Annuler</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
-  </data>
-  <data name="radioEUR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 53</value>
-  </data>
-  <data name="radioEUR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 17</value>
-  </data>
-  <data name="radioUSA.Location" type="System.Drawing.Point, System.Drawing">
-    <value>250, 53</value>
-  </data>
-  <data name="radioUSA.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
-  </data>
-  <data name="checkLinked.Location" type="System.Drawing.Point, System.Drawing">
-    <value>196, 76</value>
-  </data>
-  <data name="checkLinked.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 17</value>
   </data>
   <data name="checkLinked.Text" xml:space="preserve">
     <value>Exportation liée</value>


### PR DESCRIPTION
Linked export checkbox and label were present in FR but were hidden below the "Create saves folder" checkbox and label.
ExportGamesDialog.fr-FR.resx had positional settings and references to old buttons which other localized forms do not have. These were removed to fix #401. 

![Fixed](https://user-images.githubusercontent.com/18126283/173445256-44ca1ebf-f7c5-49ce-8ffa-c5dc35ebbdec.png)
