### PR TITLE
Fixes URI Encoder Issue

### DIFF
--- a/hakchi_gui/Controls/ImageGoogler.cs
+++ b/hakchi_gui/Controls/ImageGoogler.cs
@@ -111,7 +111,10 @@ namespace com.clusterrr.hakchi_gui.Controls
                 foreach (Match match in matches)
                 {
                     // Not sure about it.
-                    urls.Add(HttpUtility.UrlDecode(match.Groups[1].Value.Replace("\\u00", "%")));
+                    if (Uri.IsWellFormedUriString(match.Groups[1].Value, UriKind.Absolute))
+                    {
+                        urls.Add(HttpUtility.UrlDecode(match.Groups[1].Value.Replace("\\u00", "%")));
+                    }
                 }
 
                 if (urls.Count == 0)


### PR DESCRIPTION
When attempting to download the images from Google for the roms certain image results match on text that is not a valid URI.  I've added a check to confirm that the URIs are valid before adding them to the results.